### PR TITLE
Add Phaser/Vite/Express skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/docs/design-bible.md
+++ b/docs/design-bible.md
@@ -1,0 +1,1 @@
+# Design Bible

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "phaser-vite-express-skeleton",
+  "version": "1.0.0",
+  "description": "Minimal Phaser 3 game setup with Vite and Express",
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "node server.js",
+    "postinstall": "npm run build"
+  },
+  "dependencies": {
+    "express": "^4.19.0",
+    "phaser": "^3.70.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phaser Vite Express</title>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.static(join(__dirname, 'dist')));
+
+app.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});

--- a/src/gameConfig.js
+++ b/src/gameConfig.js
@@ -1,0 +1,12 @@
+export default {
+  type: Phaser.AUTO,
+  width: 1280,
+  height: 720,
+  physics: {
+    default: 'arcade',
+    arcade: {
+      gravity: { y: 500 }
+    }
+  },
+  scene: []
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,6 @@
+import Phaser from 'phaser';
+import gameConfig from './gameConfig.js';
+
+console.log('boot stub');
+
+new Phaser.Game(gameConfig);

--- a/styles/ui.css
+++ b/styles/ui.css
@@ -1,0 +1,1 @@
+/* UI styles placeholder */

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- initialize Phaser 3 + Vite project with Express server
- add public entry point and starter source files
- provide empty scene directories and placeholder docs

## Testing
- `npm install --silent` *(fails: ENOTFOUND due to no network)*
- `npm run build` *(fails: `vite` not found)*